### PR TITLE
Updated the env var to the newest syncthing version number (0.14.9)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM resin/rpi-raspbian:wheezy-2015-09-02
 
-ENV VERSION v0.11.26
+ENV VERSION v0.14.9
 
 RUN useradd -m syncthing
 


### PR DESCRIPTION
Well, not that much to say. Just an updated version number.
